### PR TITLE
Fix undefined symbol

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -2,3 +2,5 @@
 CXX17FLAGS=-O3 -Wno-unused-variable -Wno-unused-function
 CXX17 = $(BINPREF)gnu++ -m$(WIN) -std=c++17
 CXX17FLAGS=-O3 -Wno-unused-variable -Wno-unused-function
+PKG_CXXFLAGS = $(SHLIB_CXXFLAGS) 
+PKG_LIBS = $(SHLIB_CFLAGS) $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)

--- a/src/Makevars
+++ b/src/Makevars
@@ -2,3 +2,4 @@
 CXX17FLAGS=-O3 -Wno-unused-variable -Wno-unused-function
 CXX17 = $(BINPREF)gnu++ -m$(WIN) -std=c++17
 CXX17FLAGS=-O3 -Wno-unused-variable -Wno-unused-function
+CXX17 = g++-7 -std=gnu++17 -fPIC

--- a/src/Makevars
+++ b/src/Makevars
@@ -2,4 +2,3 @@
 CXX17FLAGS=-O3 -Wno-unused-variable -Wno-unused-function
 CXX17 = $(BINPREF)gnu++ -m$(WIN) -std=c++17
 CXX17FLAGS=-O3 -Wno-unused-variable -Wno-unused-function
-CXX17 = g++-7 -std=gnu++17 -fPIC


### PR DESCRIPTION
Installing fastplm on a Linux machine caused the following error:

```Error: package or namespace load failed for ‘fastplm’ in dyn.load(file, DLLpath = DLLpath, ...):
unable to load shared object 'R/x86_64-pc-linux-gnu-library/4.0/00LOCK-fastplm/00new/fastplm/libs/fastplm.so':
R/x86_64-pc-linux-gnu-library/4.0/00LOCK-fastplm/00new/fastplm/libs/fastplm.so: undefined symbol: dgesvx_
Error: loading failed
Execution halted
ERROR: loading failed
```

Possibly due to missing pointer to the LAPACK library.